### PR TITLE
私の評価を設定したら、パートナーの評価を自動的に更新されます

### DIFF
--- a/pages/input.js
+++ b/pages/input.js
@@ -130,6 +130,13 @@ export default function InputPage() {
         const personKey = (person == 'me' ? 'myTasks' : 'partnerTasks');           
         
         currentTaskRepartition[personKey][taskName] = taskRepartitionItem;
+        // "私の評価”を変更すれば、パートナーの評価も自動的に設定します。
+        if (person == 'me') {
+            currentTaskRepartition['partnerTasks'][taskName].participates = !taskRepartitionItem.participates;
+            // defaultでタスクは同じ長さにします。（後でパートナーは手動で更新できます）
+            currentTaskRepartition['partnerTasks'][taskName].duration = taskRepartitionItem.duration;
+        }
+
         setAllTaskRepartition(currentTaskRepartition);
 
     }


### PR DESCRIPTION
私の評価を変更すれば、

![image](https://user-images.githubusercontent.com/78192415/167229547-05d23d23-a264-43ef-b067-4d081e5e7086.png)

自動的にパートナーの評価も更新されます：
![image](https://user-images.githubusercontent.com/78192415/167229589-a4c9869e-48d0-4db9-91a5-214bc50b9776.png)

- 「する・しない」は自動的に更新します。
- 「タスク長さ」も更新します。
- 「パートナー評価」を変更すると、「私の評価」には影響がないです。

